### PR TITLE
Make entrypoint.sh script to fail on errors

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -l
 
 set -x
+set -e
 
 APT_DEPENDENCIES=$1
 CODECOV_TOKEN=$2


### PR DESCRIPTION
Possible cause of false positives (like an error in package installation generating a green result). I found it while testing some changes in this repository.