### PR TITLE
Source scripts instead of just executing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,7 @@ jobs:
         with:
           apt-dependencies: ''
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          script-before-cmake: before_cmake.sh
           cmake-args: '-DBUILD_TESTING=1'
-          script-between-cmake-make: between_cmake_make.sh
-          script-after-make: after_make.sh
-          script-after-make-test: after_make_test.sh
 ```
 
 ### Dependencies
@@ -47,7 +43,15 @@ Create a secret on the repository with Codecov's token, called `CODECOV_TOKEN`.
 
 ### Custom scripts
 
-The `script-`s are optional hooks that you can run at specific times of the build.
+You can add optional scripts to be run at specific times of the build:
+
+* `.github/ci-bionic/before_cmake.sh`: Runs before the `cmake` call
+* `.github/ci-bionic/between_cmake_make.sh`: Runs after the `cmake` and before `make`
+* `.github/ci-bionic/after_make.sh`: Runs after `make` and before `make test`
+* `.github/ci-bionic/after_make_test.sh`: Runs after `make test`
+
+All scripts are sourced inside the build folder. Be sure to move back to the
+build folder before exiting the script.
 
 ### Custom CMake Arguments
 

--- a/action.yml
+++ b/action.yml
@@ -13,24 +13,8 @@ inputs:
     description: 'Token to upload to Codecov'
     required: false
     default: ''
-  script-before-cmake:
-    description: 'Bash script to be run before cmake inside the build folder'
-    required: false
-    default: ''
   cmake-args:
     description: 'Additional CMake arguments to use when building package under test'
-    required: false
-    default: ''
-  script-between-cmake-make:
-    description: 'Bash script to be run after cmake and before make inside the build folder'
-    required: false
-    default: ''
-  script-after-make:
-    description: 'Bash script to be run after make and before make test inside the build folder'
-    required: false
-    default: ''
-  script-after-make-test:
-    description: 'Bash script to be run after make test inside the build folder'
     required: false
     default: ''
 runs:
@@ -39,8 +23,4 @@ runs:
   args:
     - ${{ inputs.apt-dependencies }}
     - ${{ inputs.codecov-token }}
-    - ${{ inputs.script-before-cmake }}
     - ${{ inputs.cmake-args }}
-    - ${{ inputs.script-between-cmake-make }}
-    - ${{ inputs.script-after-make }}
-    - ${{ inputs.script-after-make-test }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ cd build
 
 echo "SCRIPT_BEFORE_CMAKE"
 if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
-  source $SCRIPT_BEFORE_CMAKE
+  . $SCRIPT_BEFORE_CMAKE
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then
@@ -67,14 +67,14 @@ fi
 
 echo "SCRIPT_BETWEEN_CMAKE_MAKE"
 if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
-  source $SCRIPT_BETWEEN_CMAKE_MAKE
+  . $SCRIPT_BETWEEN_CMAKE_MAKE
 fi
 
 make
 
 echo "SCRIPT_AFTER_MAKE"
 if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
-  source $SCRIPT_AFTER_MAKE
+  . $SCRIPT_AFTER_MAKE
 fi
 
 export CTEST_OUTPUT_ON_FAILURE=1
@@ -82,7 +82,7 @@ make test
 
 echo "SCRIPT_AFTER_MAKE_TEST"
 if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
-  source $SCRIPT_AFTER_MAKE_TEST
+  . $SCRIPT_AFTER_MAKE_TEST
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ cd build
 
 echo "SCRIPT_BEFORE_CMAKE"
 if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
-  bash $SCRIPT_BEFORE_CMAKE
+  source $SCRIPT_BEFORE_CMAKE
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then
@@ -67,14 +67,14 @@ fi
 
 echo "SCRIPT_BETWEEN_CMAKE_MAKE"
 if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
-  bash $SCRIPT_BETWEEN_CMAKE_MAKE
+  source $SCRIPT_BETWEEN_CMAKE_MAKE
 fi
 
 make
 
 echo "SCRIPT_AFTER_MAKE"
 if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
-  bash $SCRIPT_AFTER_MAKE
+  source $SCRIPT_AFTER_MAKE
 fi
 
 export CTEST_OUTPUT_ON_FAILURE=1
@@ -82,7 +82,7 @@ make test
 
 echo "SCRIPT_AFTER_MAKE_TEST"
 if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
-  bash $SCRIPT_AFTER_MAKE_TEST
+  source $SCRIPT_AFTER_MAKE_TEST
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ APT_DEPENDENCIES=$1
 CODECOV_TOKEN=$2
 CMAKE_ARGS=$3
 
+SOURCE_DEPENDENCIES=".github/ci-bionic/dependencies.yaml"
 SCRIPT_BEFORE_CMAKE="../.github/ci-bionic/before_cmake.sh"
 SCRIPT_BETWEEN_CMAKE_MAKE="../.github/ci-bionic/between_cmake_make.sh"
 SCRIPT_AFTER_MAKE="../.github/ci-bionic/after_make.sh"
@@ -43,7 +44,8 @@ cd ..
 
 sh tools/code_check.sh
 
-if [ -f ".github/ci-bionic/dependencies.yaml" ] ; then
+echo ::group::Dependencies from source
+if [ -f "$SOURCE_DEPENDENCIES" ] ; then
   mkdir -p deps/src
   cd deps
   vcs import src < ../.github/ci-bionic/dependencies.yaml
@@ -55,7 +57,8 @@ fi
 mkdir build
 cd build
 
-if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
+echo ::group::Script before cmake
+if [ -f "$SCRIPT_BEFORE_CMAKE" ] ; then
   . $SCRIPT_BEFORE_CMAKE
 fi
 
@@ -65,21 +68,24 @@ else
   cmake .. $CMAKE_ARGS
 fi
 
-if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
-  . $SCRIPT_BETWEEN_CMAKE_MAKE
+echo ::group::Script between cmake and make
+if [ -f "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
+  . $SCRIPT_BETWEEN_CMAKE_MAKE 2>&1
 fi
 
 make
 
-if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
-  . $SCRIPT_AFTER_MAKE
+echo ::group::Script after make
+if [ -f "$SCRIPT_AFTER_MAKE" ] ; then
+  . $SCRIPT_AFTER_MAKE 2>&1
 fi
 
 export CTEST_OUTPUT_ON_FAILURE=1
 make test
 
-if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
-  . $SCRIPT_AFTER_MAKE_TEST
+echo ::group::Script after make test
+if [ -f "$SCRIPT_AFTER_MAKE_TEST" ] ; then
+  . $SCRIPT_AFTER_MAKE_TEST 2>&1
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,11 +5,12 @@ set -e
 
 APT_DEPENDENCIES=$1
 CODECOV_TOKEN=$2
-SCRIPT_BEFORE_CMAKE=$3
-CMAKE_ARGS=$4
-SCRIPT_BETWEEN_CMAKE_MAKE=$5
-SCRIPT_AFTER_MAKE=$6
-SCRIPT_AFTER_MAKE_TEST=$7
+CMAKE_ARGS=$3
+
+SCRIPT_BEFORE_CMAKE="../.github/ci-bionic/before_cmake.sh"
+SCRIPT_BETWEEN_CMAKE_MAKE="../.github/ci-bionic/between_cmake_make.sh"
+SCRIPT_AFTER_MAKE="../.github/ci-bionic/after_make.sh"
+SCRIPT_AFTER_MAKE_TEST="../.github/ci-bionic/after_make_test.sh"
 
 cd $GITHUB_WORKSPACE
 
@@ -54,7 +55,6 @@ fi
 mkdir build
 cd build
 
-echo "SCRIPT_BEFORE_CMAKE"
 if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
   . $SCRIPT_BEFORE_CMAKE
 fi
@@ -65,14 +65,12 @@ else
   cmake .. $CMAKE_ARGS
 fi
 
-echo "SCRIPT_BETWEEN_CMAKE_MAKE"
 if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
   . $SCRIPT_BETWEEN_CMAKE_MAKE
 fi
 
 make
 
-echo "SCRIPT_AFTER_MAKE"
 if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
   . $SCRIPT_AFTER_MAKE
 fi
@@ -80,7 +78,6 @@ fi
 export CTEST_OUTPUT_ON_FAILURE=1
 make test
 
-echo "SCRIPT_AFTER_MAKE_TEST"
 if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
   . $SCRIPT_AFTER_MAKE_TEST
 fi


### PR DESCRIPTION
This allows the scripts to set environment variables that will be reflected in the calling script.

This will break any jobs that moved folders within the scripts and didn't go back to the build folder.