### PR TITLE
Support apt dependencies in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,7 @@ jobs:
         with:
           apt-dependencies: ''
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          script-before-cmake: before_cmake.sh
           cmake-args: '-DBUILD_TESTING=1'
-          script-between-cmake-make: between_cmake_make.sh
-          script-after-make: after_make.sh
-          script-after-make-test: after_make_test.sh
 ```
 
 ### Dependencies
@@ -47,7 +43,15 @@ Create a secret on the repository with Codecov's token, called `CODECOV_TOKEN`.
 
 ### Custom scripts
 
-The `script-`s are optional hooks that you can run at specific times of the build.
+You can add optional scripts to be run at specific times of the build:
+
+* `.github/ci-bionic/before_cmake.sh`: Runs before the `cmake` call
+* `.github/ci-bionic/between_cmake_make.sh`: Runs after the `cmake` and before `make`
+* `.github/ci-bionic/after_make.sh`: Runs after `make` and before `make test`
+* `.github/ci-bionic/after_make_test.sh`: Runs after `make test`
+
+All scripts are sourced inside the build folder. Be sure to move back to the
+build folder before exiting the script.
 
 ### Custom CMake Arguments
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ jobs:
 
 #### APT dependencies
 
-Be sure to declare all apt-installable dependencies in a flat list into:
+Be sure to declare all apt-installable dependencies in the following file, one
+package per line.
 
 `.github/ci-bionic/packages.apt`
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
 Be sure to declare all apt-installable dependencies in the following file, one
 package per line.
 
-`.github/ci-bionic/packages.apt`
+`.github/ci/packages-bionic.apt`
 
 > The `apt-dependencies` input is deprecated.
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ jobs:
 
 #### APT dependencies
 
-Be sure to declare all apt-installable dependencies in the following file, one
+Be sure to declare all apt-installable dependencies in the following files, one
 package per line.
 
-`.github/ci/packages-bionic.apt`
+* `.github/ci/packages.apt` : Installed for all versions.
+* `.github/ci/packages-<ubuntu version>.apt` : where `<ubuntu version>` can be
+  bionic, focal, etc. Use these if you need to install different dependencies
+  according to the distribution.
 
 > The `apt-dependencies` input is deprecated.
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,21 @@ jobs:
         id: ci
         uses: ignition-tooling/ubuntu-bionic-ci-action@v1
         with:
-          apt-dependencies: ''
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           cmake-args: '-DBUILD_TESTING=1'
 ```
 
 ### Dependencies
 
-Be sure to put all apt-installable dependencies into `apt-dependencies`.
+#### APT dependencies
+
+Be sure to declare all apt-installable dependencies in a flat list into:
+
+`.github/ci-bionic/packages.apt`
+
+> The `apt-dependencies` input is deprecated.
+
+#### Source dependencies
 
 If you need to install dependencies from source, add a Vcstool yaml file to
 `.github/ci-bionic/dependencies.yaml`. Dependencies will be built using

--- a/action.yml
+++ b/action.yml
@@ -13,24 +13,8 @@ inputs:
     description: 'Token to upload to Codecov'
     required: false
     default: ''
-  script-before-cmake:
-    description: 'Bash script to be run before cmake inside the build folder'
-    required: false
-    default: ''
   cmake-args:
     description: 'Additional CMake arguments to use when building package under test'
-    required: false
-    default: ''
-  script-between-cmake-make:
-    description: 'Bash script to be run after cmake and before make inside the build folder'
-    required: false
-    default: ''
-  script-after-make:
-    description: 'Bash script to be run after make and before make test inside the build folder'
-    required: false
-    default: ''
-  script-after-make-test:
-    description: 'Bash script to be run after make test inside the build folder'
     required: false
     default: ''
 runs:
@@ -39,8 +23,4 @@ runs:
   args:
     - ${{ inputs.apt-dependencies }}
     - ${{ inputs.codecov-token }}
-    - ${{ inputs.script-before-cmake }}
     - ${{ inputs.cmake-args }}
-    - ${{ inputs.script-between-cmake-make }}
-    - ${{ inputs.script-after-make }}
-    - ${{ inputs.script-after-make-test }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ cd build
 
 echo "SCRIPT_BEFORE_CMAKE"
 if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
-  source $SCRIPT_BEFORE_CMAKE
+  . $SCRIPT_BEFORE_CMAKE
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then
@@ -67,14 +67,14 @@ fi
 
 echo "SCRIPT_BETWEEN_CMAKE_MAKE"
 if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
-  source $SCRIPT_BETWEEN_CMAKE_MAKE
+  . $SCRIPT_BETWEEN_CMAKE_MAKE
 fi
 
 make
 
 echo "SCRIPT_AFTER_MAKE"
 if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
-  source $SCRIPT_AFTER_MAKE
+  . $SCRIPT_AFTER_MAKE
 fi
 
 export CTEST_OUTPUT_ON_FAILURE=1
@@ -82,7 +82,7 @@ make test
 
 echo "SCRIPT_AFTER_MAKE_TEST"
 if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
-  source $SCRIPT_AFTER_MAKE_TEST
+  . $SCRIPT_AFTER_MAKE_TEST
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,14 +15,12 @@ SCRIPT_AFTER_MAKE_TEST="`pwd`/.github/ci-bionic/after_make_test.sh"
 
 cd $GITHUB_WORKSPACE
 
-echo ::group::Install tools
-
-echo ::group::apt
+echo ::group::Install tools: apt
 apt update
 apt -y install wget lsb-release gnupg
 sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" > /etc/apt/sources.list.d/gazebo-stable.list'
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
-apt-get update
+apt-get update 2>&1
 apt -y install \
   cmake \
   build-essential \
@@ -33,17 +31,15 @@ apt -y install \
   python3-pip
 echo ::endgroup::
 
-echo ::group::pip
+echo ::group::Install tools: pip
 pip3 install -U pip vcstool colcon-common-extensions
 echo ::endgroup::
 
-echo ::group::source
+echo ::group::Install tools: source
 git clone https://github.com/linux-test-project/lcov.git -b v1.14 2>&1
 cd lcov
 make install
 cd ..
-echo ::endgroup::
-
 echo ::endgroup::
 
 echo ::group::GCC 8

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ cd build
 
 echo "SCRIPT_BEFORE_CMAKE"
 if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
-  bash $SCRIPT_BEFORE_CMAKE
+  source $SCRIPT_BEFORE_CMAKE
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then
@@ -67,14 +67,14 @@ fi
 
 echo "SCRIPT_BETWEEN_CMAKE_MAKE"
 if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
-  bash $SCRIPT_BETWEEN_CMAKE_MAKE
+  source $SCRIPT_BETWEEN_CMAKE_MAKE
 fi
 
 make
 
 echo "SCRIPT_AFTER_MAKE"
 if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
-  bash $SCRIPT_AFTER_MAKE
+  source $SCRIPT_AFTER_MAKE
 fi
 
 export CTEST_OUTPUT_ON_FAILURE=1
@@ -82,7 +82,7 @@ make test
 
 echo "SCRIPT_AFTER_MAKE_TEST"
 if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
-  bash $SCRIPT_AFTER_MAKE_TEST
+  source $SCRIPT_AFTER_MAKE_TEST
 fi
 
 if [ ! -z "$CODECOV_TOKEN" ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,14 +49,12 @@ update-alternatives \
   --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 echo ::endgroup::
 
-echo ::group::Fetch source dependencies
 if [ -f "$SOURCE_DEPENDENCIES" ] ; then
+  echo ::group::Fetch source dependencies
   mkdir -p deps/src
-  cd deps
-  vcs import src < ../.github/ci-bionic/dependencies.yaml
-  cd ..
+  vcs import deps/src < ../.github/ci-bionic/dependencies.yaml
+  echo ::endgroup::
 fi
-echo ::endgroup::
 
 echo ::group::Install dependencies from binaries
 apt -y install \
@@ -64,14 +62,14 @@ apt -y install \
   $(sort -u $(find . -iname 'packages.apt') | tr '\n' ' ')
 echo ::endgroup::
 
-echo ::group::Compile dependencies from source
 if [ -f "$SOURCE_DEPENDENCIES" ] ; then
+  echo ::group::Compile dependencies from source
   cd deps
   colcon build --symlink-install --merge-install --cmake-args -DBUILD_TESTING=false
   . install/setup.sh
   cd ..
+  echo ::endgroup::
 fi
-echo ::endgroup::
 
 echo ::group::Code check
 sh tools/code_check.sh 2>&1
@@ -82,11 +80,11 @@ mkdir build
 cd build
 echo ::endgroup::
 
-echo ::group::Script before cmake
 if [ -f "$SCRIPT_BEFORE_CMAKE" ] ; then
+  echo ::group::Script before cmake
   . $SCRIPT_BEFORE_CMAKE
+  echo ::endgroup::
 fi
-echo ::endgroup::
 
 echo ::group::cmake
 if [ ! -z "$CODECOV_TOKEN" ] ; then
@@ -96,40 +94,40 @@ else
 fi
 echo ::endgroup::
 
-echo ::group::Script between cmake and make
 if [ -f "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
+  echo ::group::Script between cmake and make
   . $SCRIPT_BETWEEN_CMAKE_MAKE 2>&1
+  echo ::endgroup::
 fi
-echo ::endgroup::
 
 echo ::group::make
 make
 echo ::endgroup::
 
-echo ::group::Script after make
 if [ -f "$SCRIPT_AFTER_MAKE" ] ; then
+  echo ::group::Script after make
   . $SCRIPT_AFTER_MAKE 2>&1
+  echo ::endgroup::
 fi
-echo ::endgroup::
 
 echo ::group::make test
 export CTEST_OUTPUT_ON_FAILURE=1
 make test
 echo ::endgroup::
 
-echo ::group::Script after make test
 if [ -f "$SCRIPT_AFTER_MAKE_TEST" ] ; then
+  echo ::group::Script after make test
   . $SCRIPT_AFTER_MAKE_TEST 2>&1
+  echo ::endgroup::
 fi
-echo ::endgroup::
 
-echo ::group::codecov
 if [ ! -z "$CODECOV_TOKEN" ] ; then
+  echo ::group::codecov
   make coverage VERBOSE=1
 
   curl -s https://codecov.io/bash > codecov.sh
 
   # disable gcov output with `-X gcovout -X gcov`
   bash codecov.sh -t $CODECOV_TOKEN -X gcovout -X gcov
+  echo ::endgroup::
 fi
-echo ::endgroup::

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,12 +7,6 @@ OLD_APT_DEPENDENCIES=$1
 CODECOV_TOKEN=$2
 CMAKE_ARGS=$3
 
-SOURCE_DEPENDENCIES="`pwd`/.github/ci-bionic/dependencies.yaml"
-SCRIPT_BEFORE_CMAKE="`pwd`/.github/ci-bionic/before_cmake.sh"
-SCRIPT_BETWEEN_CMAKE_MAKE="`pwd`/.github/ci-bionic/between_cmake_make.sh"
-SCRIPT_AFTER_MAKE="`pwd`/.github/ci-bionic/after_make.sh"
-SCRIPT_AFTER_MAKE_TEST="`pwd`/.github/ci-bionic/after_make_test.sh"
-
 cd "$GITHUB_WORKSPACE"
 
 echo ::group::Install tools: apt
@@ -28,6 +22,14 @@ apt -y install \
   lsb-release \
   python3-pip \
   wget
+
+UBUNTU_VERSION=`lsb_release -cs`
+
+SOURCE_DEPENDENCIES="`pwd`/.github/ci-$UBUNTU_VERSION/dependencies.yaml"
+SCRIPT_BEFORE_CMAKE="`pwd`/.github/ci-$UBUNTU_VERSION/before_cmake.sh"
+SCRIPT_BETWEEN_CMAKE_MAKE="`pwd`/.github/ci-$UBUNTU_VERSION/between_cmake_make.sh"
+SCRIPT_AFTER_MAKE="`pwd`/.github/ci-$UBUNTU_VERSION/after_make.sh"
+SCRIPT_AFTER_MAKE_TEST="`pwd`/.github/ci-$UBUNTU_VERSION/after_make_test.sh"
 
 # Infer package name from GITHUB_REPOSITORY
 PACKAGE=$(echo "$GITHUB_REPOSITORY" | sed 's:.*/::' | sed 's:ign-:ignition-:')
@@ -63,14 +65,14 @@ echo ::endgroup::
 if [ -f "$SOURCE_DEPENDENCIES" ] ; then
   echo ::group::Fetch source dependencies
   mkdir -p deps/src
-  vcs import deps/src < ../.github/ci-bionic/dependencies.yaml
+  vcs import deps/src < ../.github/ci-$UBUNTU_VERSION/dependencies.yaml
   echo ::endgroup::
 fi
 
 echo ::group::Install dependencies from binaries
 apt -y install \
   $OLD_APT_DEPENDENCIES \
-  $(sort -u $(find . -iname 'packages.apt') | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'$UBUNTU_VERSION'.apt') | tr '\n' ' ')
 echo ::endgroup::
 
 if [ -f "$SOURCE_DEPENDENCIES" ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,11 +7,11 @@ APT_DEPENDENCIES=$1
 CODECOV_TOKEN=$2
 CMAKE_ARGS=$3
 
-SOURCE_DEPENDENCIES=".github/ci-bionic/dependencies.yaml"
-SCRIPT_BEFORE_CMAKE="../.github/ci-bionic/before_cmake.sh"
-SCRIPT_BETWEEN_CMAKE_MAKE="../.github/ci-bionic/between_cmake_make.sh"
-SCRIPT_AFTER_MAKE="../.github/ci-bionic/after_make.sh"
-SCRIPT_AFTER_MAKE_TEST="../.github/ci-bionic/after_make_test.sh"
+SOURCE_DEPENDENCIES="`pwd`/.github/ci-bionic/dependencies.yaml"
+SCRIPT_BEFORE_CMAKE="`pwd`/.github/ci-bionic/before_cmake.sh"
+SCRIPT_BETWEEN_CMAKE_MAKE="`pwd`/.github/ci-bionic/between_cmake_make.sh"
+SCRIPT_AFTER_MAKE="`pwd`/.github/ci-bionic/after_make.sh"
+SCRIPT_AFTER_MAKE_TEST="`pwd`/.github/ci-bionic/after_make_test.sh"
 
 cd $GITHUB_WORKSPACE
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ APT_DEPENDENCIES=$1
 CODECOV_TOKEN=$2
 CMAKE_ARGS=$3
 
+SOURCE_DEPENDENCIES=".github/ci-bionic/dependencies.yaml"
 SCRIPT_BEFORE_CMAKE="../.github/ci-bionic/before_cmake.sh"
 SCRIPT_BETWEEN_CMAKE_MAKE="../.github/ci-bionic/between_cmake_make.sh"
 SCRIPT_AFTER_MAKE="../.github/ci-bionic/after_make.sh"
@@ -52,7 +53,7 @@ sh tools/code_check.sh 2>&1
 echo ::endgroup::
 
 echo ::group::Dependencies from source
-if [ -f ".github/ci-bionic/dependencies.yaml" ] ; then
+if [ -f "$SOURCE_DEPENDENCIES" ] ; then
   mkdir -p deps/src
   cd deps
   vcs import src < ../.github/ci-bionic/dependencies.yaml
@@ -66,7 +67,7 @@ cd build
 echo ::endgroup::
 
 echo ::group::Script before cmake
-if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
+if [ -f "$SCRIPT_BEFORE_CMAKE" ] ; then
   . $SCRIPT_BEFORE_CMAKE
 fi
 echo ::endgroup::
@@ -80,7 +81,7 @@ fi
 echo ::endgroup::
 
 echo ::group::Script between cmake and make
-if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
+if [ -f "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
   . $SCRIPT_BETWEEN_CMAKE_MAKE 2>&1
 fi
 echo ::endgroup::
@@ -90,7 +91,7 @@ make
 echo ::endgroup::
 
 echo ::group::Script after make
-if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
+if [ -f "$SCRIPT_AFTER_MAKE" ] ; then
   . $SCRIPT_AFTER_MAKE 2>&1
 fi
 echo ::endgroup::
@@ -101,7 +102,7 @@ make test
 echo ::endgroup::
 
 echo ::group::Script after make test
-if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
+if [ -f "$SCRIPT_AFTER_MAKE_TEST" ] ; then
   . $SCRIPT_AFTER_MAKE_TEST 2>&1
 fi
 echo ::endgroup::

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ fi
 echo ::group::Install dependencies from binaries
 apt -y install \
   $OLD_APT_DEPENDENCIES \
-  $(sort -u $(find . -iname 'packages-'$UBUNTU_VERSION'.apt') | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'$UBUNTU_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
 echo ::endgroup::
 
 if [ -f "$SOURCE_DEPENDENCIES" ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,11 @@
 set -x
 set -e
 
-APT_DEPENDENCIES=$1
+OLD_APT_DEPENDENCIES=$1
 CODECOV_TOKEN=$2
 CMAKE_ARGS=$3
 
+APT_DEPENDENCIES="`pwd`/.github/ci-bionic/packages.apt"
 SOURCE_DEPENDENCIES="`pwd`/.github/ci-bionic/dependencies.yaml"
 SCRIPT_BEFORE_CMAKE="`pwd`/.github/ci-bionic/before_cmake.sh"
 SCRIPT_BETWEEN_CMAKE_MAKE="`pwd`/.github/ci-bionic/between_cmake_make.sh"
@@ -29,7 +30,9 @@ apt -y install \
   git \
   cppcheck \
   python3-pip \
-  $APT_DEPENDENCIES
+  $OLD_APT_DEPENDENCIES \
+  $(sort -u $APT_DEPENDENCIES | tr '\n' ' ')
+
 
 pip3 install -U pip vcstool colcon-common-extensions
 echo ::endgroup::

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ SCRIPT_AFTER_MAKE_TEST="../.github/ci-bionic/after_make_test.sh"
 
 cd $GITHUB_WORKSPACE
 
+echo ::group::Dependencies from binaries
 apt update
 apt -y install wget lsb-release gnupg
 sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" > /etc/apt/sources.list.d/gazebo-stable.list'
@@ -30,19 +31,27 @@ apt -y install \
   $APT_DEPENDENCIES
 
 pip3 install -U pip vcstool colcon-common-extensions
+echo ::endgroup::
 
+echo ::group::GCC 8
 update-alternatives \
   --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 \
   --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
   --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+echo ::endgroup::
 
-git clone https://github.com/linux-test-project/lcov.git -b v1.14
+echo ::group::Install LCOV
+git clone https://github.com/linux-test-project/lcov.git -b v1.14 2>&1
 cd lcov
 make install
 cd ..
+echo ::endgroup::
 
-sh tools/code_check.sh
+echo ::group::Code check
+sh tools/code_check.sh 2>&1
+echo ::endgroup::
 
+echo ::group::Dependencies from source
 if [ -f ".github/ci-bionic/dependencies.yaml" ] ; then
   mkdir -p deps/src
   cd deps
@@ -54,34 +63,50 @@ fi
 
 mkdir build
 cd build
+echo ::endgroup::
 
+echo ::group::Script before cmake
 if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
   . $SCRIPT_BEFORE_CMAKE
 fi
+echo ::endgroup::
 
+echo ::group::cmake
 if [ ! -z "$CODECOV_TOKEN" ] ; then
   cmake .. $CMAKE_ARGS -DCMAKE_BUILD_TYPE=coverage
 else
   cmake .. $CMAKE_ARGS
 fi
+echo ::endgroup::
 
+echo ::group::Script between cmake and make
 if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
-  . $SCRIPT_BETWEEN_CMAKE_MAKE
+  . $SCRIPT_BETWEEN_CMAKE_MAKE 2>&1
 fi
+echo ::endgroup::
 
+echo ::group::make
 make
+echo ::endgroup::
 
+echo ::group::Script after make
 if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
-  . $SCRIPT_AFTER_MAKE
+  . $SCRIPT_AFTER_MAKE 2>&1
 fi
+echo ::endgroup::
 
+echo ::group::make test
 export CTEST_OUTPUT_ON_FAILURE=1
 make test
+echo ::endgroup::
 
+echo ::group::Script after make test
 if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
-  . $SCRIPT_AFTER_MAKE_TEST
+  . $SCRIPT_AFTER_MAKE_TEST 2>&1
 fi
+echo ::endgroup::
 
+echo ::group::codecov
 if [ ! -z "$CODECOV_TOKEN" ] ; then
   make coverage VERBOSE=1
 
@@ -90,3 +115,4 @@ if [ ! -z "$CODECOV_TOKEN" ] ; then
   # disable gcov output with `-X gcovout -X gcov`
   bash codecov.sh -t $CODECOV_TOKEN -X gcovout -X gcov
 fi
+echo ::endgroup::

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,11 +5,12 @@ set -e
 
 APT_DEPENDENCIES=$1
 CODECOV_TOKEN=$2
-SCRIPT_BEFORE_CMAKE=$3
-CMAKE_ARGS=$4
-SCRIPT_BETWEEN_CMAKE_MAKE=$5
-SCRIPT_AFTER_MAKE=$6
-SCRIPT_AFTER_MAKE_TEST=$7
+CMAKE_ARGS=$3
+
+SCRIPT_BEFORE_CMAKE="../.github/ci-bionic/before_cmake.sh"
+SCRIPT_BETWEEN_CMAKE_MAKE="../.github/ci-bionic/between_cmake_make.sh"
+SCRIPT_AFTER_MAKE="../.github/ci-bionic/after_make.sh"
+SCRIPT_AFTER_MAKE_TEST="../.github/ci-bionic/after_make_test.sh"
 
 cd $GITHUB_WORKSPACE
 
@@ -54,7 +55,6 @@ fi
 mkdir build
 cd build
 
-echo "SCRIPT_BEFORE_CMAKE"
 if [ ! -z "$SCRIPT_BEFORE_CMAKE" ] ; then
   . $SCRIPT_BEFORE_CMAKE
 fi
@@ -65,14 +65,12 @@ else
   cmake .. $CMAKE_ARGS
 fi
 
-echo "SCRIPT_BETWEEN_CMAKE_MAKE"
 if [ ! -z "$SCRIPT_BETWEEN_CMAKE_MAKE" ] ; then
   . $SCRIPT_BETWEEN_CMAKE_MAKE
 fi
 
 make
 
-echo "SCRIPT_AFTER_MAKE"
 if [ ! -z "$SCRIPT_AFTER_MAKE" ] ; then
   . $SCRIPT_AFTER_MAKE
 fi
@@ -80,7 +78,6 @@ fi
 export CTEST_OUTPUT_ON_FAILURE=1
 make test
 
-echo "SCRIPT_AFTER_MAKE_TEST"
 if [ ! -z "$SCRIPT_AFTER_MAKE_TEST" ] ; then
   . $SCRIPT_AFTER_MAKE_TEST
 fi


### PR DESCRIPTION
Move apt dependencies to a file. The advantage is that the dependencies can be declared once, and multiple actions / CIs can make use of it.

We had also considered keeping all apt dependencies in a central place. This is still up for discussion. Personally, I think that the closer it is to the code, the easier it is to maintain. The change of a dependency will often happen together with a change to `find_package` on the source code.

This keeps support for the old way of specifying dependencies so we can migrate to the new style without breaking many things on the way.