### PR TITLE
Rework the codecov support: deprecate codecov-token add hash checks for uploader

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,12 @@ inputs:
     description: 'Dependencies to apt install'
     required: false
     default: ''
+  codecov-enabled:
+    description: 'Prepare the build for coverage and execute codecov'
+    required: false
+    default: ''
   codecov-token:
-    description: 'Token to upload to Codecov'
+    description: 'Token to upload to Codecov. Only for private repositories'
     required: false
     default: ''
   cmake-args:
@@ -38,5 +42,6 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.apt-dependencies }}
+    - ${{ inputs.codecov-enabled }}
     - ${{ inputs.codecov-token }}
     - ${{ inputs.cmake-args }}

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,15 @@ inputs:
     description: 'Prepare the build for coverage and execute codecov'
     required: false
     default: ''
-  codecov-token:
-    description: 'Token to upload to Codecov. Only for private repositories'
+  codecov-token-private-repos:
+    description: 'Token to upload to codecov in private repositories. Public repos do not need it'
     required: false
     default: ''
+  codecov-token:
+    description: 'DEPRECATED: use codecov-token-private if using private repositories'
+    required: false
+    default: ''
+    deprecationMessage: 'Public repositories do not need codecov-token, use codecov-enabled to run codecov on Public repositories. To facilitate transition codecov is enabled but not using any token'
   cmake-args:
     description: 'Additional CMake arguments to use when building package under test'
     required: false
@@ -43,5 +48,6 @@ runs:
   args:
     - ${{ inputs.apt-dependencies }}
     - ${{ inputs.codecov-enabled }}
+    - ${{ inputs.codecov-token-private-repos }}
     - ${{ inputs.codecov-token }}
     - ${{ inputs.cmake-args }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,12 @@ set -e
 
 OLD_APT_DEPENDENCIES=$1
 CODECOV_ENABLED=$2
-CODECOV_TOKEN=$3
-CMAKE_ARGS=$4
+CODECOV_TOKEN_PRIVATE_REPOS=$3
+DEPRECATED_CODECOV_TOKEN=$4
+CMAKE_ARGS=$5
+
+# keep the previous behaviour of running codecov if old token is set
+[ -n "${DEPRECATED_CODECOV_TOKEN}" ] && CODECOV_ENABLED=1
 
 export DEBIAN_FRONTEND="noninteractive"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,7 +118,7 @@ if [ -f "$SCRIPT_BEFORE_CMAKE" ] || [ -f "$SCRIPT_BEFORE_CMAKE_VERSIONED" ] ; th
 fi
 
 echo ::group::cmake
-if [ ! -z "$CODECOV_TOKEN" ] ; then
+if [ -n "$CODECOV_ENABLED" ] && ${CODECOV_ENABLED} ; then
   cmake .. $CMAKE_ARGS -DCMAKE_BUILD_TYPE=coverage
 else
   cmake .. $CMAKE_ARGS
@@ -180,7 +180,7 @@ if [ -f "$SCRIPT_AFTER_MAKE_TEST" ] || [ -f "$SCRIPT_AFTER_MAKE_TEST_VERSIONED" 
   echo ::endgroup::
 fi
 
-if [ -n "$CODECOV_ENABLED" ] ; then
+if [ -n "$CODECOV_ENABLED" ] && ${CODECOV_ENABLED} ; then
   echo ::group::codecov
   make coverage VERBOSE=1
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -187,9 +187,9 @@ if [ -n "$CODECOV_ENABLED" ] ; then
   # Download codecov, check hash
   curl -s https://codecov.io/bash > codecov
   curl -s https://codecov.io/env > env # needed to make the checksum work
-  export VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
-  shasum -a 512 -c  <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA521SUM") ||
-    shasum -a 512 -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM")
+  VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
+  curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM" > hash_file
+  shasum -a 512 -c hash_file
   # disable gcov output with `-X gcovout -X gcov`
   private_repo_token=
   [ -n "${CODECOV_TOKEN}" ] && private_repo_token="-t $CODECOV_TOKEN"


### PR DESCRIPTION
The PR deprecates the use of `codecov-token` input since I think that we have wrongly used the token for public repositories when there was no need for that. The code using it should keep working the same.

Added a couple of new inputs: `codecov-enabled` to enable the codecov runs and `codecov-token-private-repos` to make explicit the exact use of the token. 

I've also added the hash check for codecov bash uploader. I've tested this branch here:
https://github.com/j-rivero/ign-math/pull/1