### PR TITLE
Rework the codecov support: deprecate codecov-token add hash checks for uploader (focal)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,19 @@ inputs:
     description: 'Dependencies to apt install'
     required: false
     default: ''
-  codecov-token:
-    description: 'Token to upload to Codecov'
+  codecov-enabled:
+    description: 'Prepare the build for coverage and execute codecov'
     required: false
     default: ''
+  codecov-token-private-repos:
+    description: 'Token to upload to codecov in private repositories. Public repos do not need it'
+    required: false
+    default: ''
+  codecov-token:
+    description: 'DEPRECATED: use codecov-token-private if using private repositories'
+    required: false
+    default: ''
+    deprecationMessage: 'Public repositories do not need codecov-token, use codecov-enabled to run codecov on Public repositories. To facilitate transition codecov is enabled but not using any token'
   cmake-args:
     description: 'Additional CMake arguments to use when building package under test'
     required: false
@@ -22,5 +31,7 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.apt-dependencies }}
+    - ${{ inputs.codecov-enabled }}
+    - ${{ inputs.codecov-token-private-repos }}
     - ${{ inputs.codecov-token }}
     - ${{ inputs.cmake-args }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,13 @@ set -x
 set -e
 
 OLD_APT_DEPENDENCIES=$1
-CODECOV_TOKEN=$2
-CMAKE_ARGS=$3
+CODECOV_ENABLED=$2
+CODECOV_TOKEN_PRIVATE_REPOS=$3
+DEPRECATED_CODECOV_TOKEN=$4
+CMAKE_ARGS=$5
+
+# keep the previous behaviour of running codecov if old token is set
+[ -n "${DEPRECATED_CODECOV_TOKEN}" ] && CODECOV_ENABLED=1
 
 export DEBIAN_FRONTEND="noninteractive"
 
@@ -111,7 +116,7 @@ if [ -f "$SCRIPT_BEFORE_CMAKE" ] || [ -f "$SCRIPT_BEFORE_CMAKE_VERSIONED" ] ; th
 fi
 
 echo ::group::cmake
-if [ ! -z "$CODECOV_TOKEN" ] ; then
+if [ -n "$CODECOV_ENABLED" ] && ${CODECOV_ENABLED} ; then
   cmake .. $CMAKE_ARGS -DCMAKE_BUILD_TYPE=coverage
 else
   cmake .. $CMAKE_ARGS
@@ -161,13 +166,19 @@ if [ -f "$SCRIPT_AFTER_MAKE_TEST" ] || [ -f "$SCRIPT_AFTER_MAKE_TEST_VERSIONED" 
   echo ::endgroup::
 fi
 
-if [ ! -z "$CODECOV_TOKEN" ] ; then
+if [ -n "$CODECOV_ENABLED" ] && ${CODECOV_ENABLED} ; then
   echo ::group::codecov
   make coverage VERBOSE=1
 
-  curl -s https://codecov.io/bash > codecov.sh
-
+ # Download codecov, check hash
+  curl -s https://codecov.io/bash > codecov
+  curl -s https://codecov.io/env > env # needed to make the checksum work
+  VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
+  curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM" > hash_file
+  shasum -a 512 -c hash_file
   # disable gcov output with `-X gcovout -X gcov`
-  bash codecov.sh -t $CODECOV_TOKEN -X gcovout -X gcov
+  private_repo_token=
+  [ -n "${CODECOV_TOKEN}" ] && private_repo_token="-t $CODECOV_TOKEN"
+  bash codecov ${private_repo_token} -X gcovout -X gcov
   echo ::endgroup::
 fi


### PR DESCRIPTION
Focal branch version of #32