### PR TITLE
Add flags for cpplint and cppcheck to focal

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: 'Run tests.'
     required: false
     default: 'true'
+  cpplint-enabled:
+    description: 'Run cpplint'
+    required: false
+    default: 'false'
+  cppcheck-enabled:
+    description: 'Run cppcheck'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -45,3 +53,5 @@ runs:
     - ${{ inputs.cmake-args }}
     - ${{ inputs.doxygen-enabled }}
     - ${{ inputs.tests-enabled }}
+    - ${{ inputs.cpplint-enabled }}
+    - ${{ inputs.cppcheck-enabled }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,8 @@ DEPRECATED_CODECOV_TOKEN=$4
 CMAKE_ARGS=$5
 DOXYGEN_ENABLED=$6
 TESTS_ENABLED=$7
+CPPLINT_ENABLED=$8
+CPPCHECK_ENABLED=$9
 
 # keep the previous behaviour of running codecov if old token is set
 [ -n "${DEPRECATED_CODECOV_TOKEN}" ] && CODECOV_ENABLED=1
@@ -121,7 +123,21 @@ else
 fi
 echo ::endgroup::
 
-# Skip codecheck for focal because we can't accommodate more than 1 cppcheck version
+echo ::group::cpplint
+if [ -n "$CPPLINT_ENABLED" ] && ${CPPLINT_ENABLED} ; then
+  if grep -iq cpplint Makefile; then
+    make cpplint 2>&1
+  fi
+fi
+echo ::endgroup
+
+echo ::group::cppcheck
+if [ -n "$CPPCHECK_ENABLED" ] && ${CPPCHECK_ENABLED} ; then
+  if grep -iq cppcheck Makefile; then
+    make cppcheck 2>&1
+  fi
+fi
+echo ::endgroup
 
 if [ -n "$DOXYGEN_ENABLED" ] && ${DOXYGEN_ENABLED} ; then
   echo ::group::Documentation check


### PR DESCRIPTION
Addresses #42 by adding options for cpplint and cppcheck.

I opted to make the flags separate because I believe all of our libraries will pass cpplint on `focal`, but very few will pass `cppcheck`.  This will allow us to turn each on a case-by-case basis.

Signed-off-by: Michael Carroll <michael@openrobotics.org>