### PR TITLE
Try checking out ci_matching_branch for gzdev

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,16 @@ PACKAGE=$(echo "$GITHUB_REPOSITORY" | sed 's:.*/::' | sed 's:ign-:ignition-:')
 wget https://raw.githubusercontent.com/ignition-tooling/release-tools/master/jenkins-scripts/tools/detect_cmake_major_version.py
 PACKAGE_MAJOR_VERSION=$(python3 detect_cmake_major_version.py "$GITHUB_WORKSPACE"/CMakeLists.txt)
 
-git clone --depth 1 https://github.com/osrf/gzdev /tmp/gzdev
+# Check for ci_matching_branch in gzdev
+wget https://raw.githubusercontent.com/ignition-tooling/release-tools/master/jenkins-scripts/tools/detect_ci_matching_branch.py
+if python3 detect_ci_matching_branch.py "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"; then
+  GZDEV_TRY_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+fi
+
+git clone https://github.com/osrf/gzdev /tmp/gzdev
+if [ -n "${GZDEV_TRY_BRANCH}" ]; then
+  git -C /tmp/gzdev checkout ${GZDEV_TRY_BRANCH} || true
+fi
 pip3 install -r /tmp/gzdev/requirements.txt
 /tmp/gzdev/gzdev.py \
   repository enable --project="${PACKAGE}${PACKAGE_MAJOR_VERSION}"


### PR DESCRIPTION
Code copied from release-tools#572 with the magic `${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}` copied from [drake_vendor's CI configuration](https://github.com/ToyotaResearchInstitute/drake_vendor/blob/8ee500779c2105756f406b8ff85065dc6b661e77/.github/workflows/build.yml#L111) to return the current branch for both GitHub workflow Push and Pull-Request events.

Testing with https://github.com/ignitionrobotics/sdformat/pull/780 since it needs the ign-cmake2 2.10.0~pre1 prerelease and a matching `gzdev` branch:

* https://github.com/ignition-tooling/gzdev/tree/ci_matching_branch/use-ign-cmake-10

Note that the focal workflows are failing on that PR. I'll update the `focal` branch once this is merged.