### PR TITLE
[focal] Bump LCOV version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,7 +75,7 @@ pip3 install -U pip vcstool colcon-common-extensions
 echo ::endgroup::
 
 echo ::group::Install tools: source
-git clone https://github.com/linux-test-project/lcov.git -b v1.14 2>&1
+git clone https://github.com/linux-test-project/lcov.git -b v1.15 2>&1
 cd lcov
 make install
 cd ..


### PR DESCRIPTION
1.14 is failing for focal, see https://github.com/ignitionrobotics/ign-common/pull/284.

Locally, 1.15 worked for me. I'll test with that PR.