### PR TITLE
Don't install doxygen if linter is disabled

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,13 +25,16 @@ apt -y install \
   cmake \
   cppcheck \
   curl \
-  doxygen \
   g++-8 \
   git \
   gnupg \
   lsb-release \
   python3-pip \
   wget
+
+if [ -n "$DOXYGEN_ENABLED" ] && ${DOXYGEN_ENABLED} ; then
+  apt -y install doxygen
+fi
 
 SYSTEM_VERSION=`lsb_release -cs`
 


### PR DESCRIPTION
Should save a bit of compilation time, and work around doxygen issues like https://github.com/ignitionrobotics/ign-gazebo/issues/1409