### PR TITLE
Don't install doxygen if linter is disabled

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,13 +27,16 @@ apt -y install \
   cmake \
   cppcheck \
   curl \
-  doxygen \
   g++-8 \
   git \
   gnupg \
   lsb-release \
   python3-pip \
   wget
+
+if [ -n "$DOXYGEN_ENABLED" ] && ${DOXYGEN_ENABLED} ; then
+  apt -y install doxygen
+fi
 
 SYSTEM_VERSION=`lsb_release -cs`
 


### PR DESCRIPTION
Same as #51, but for Focal