### PR TITLE
Add script hook before dependency compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,8 @@ repositories:
     version: branch_name
 ```
 
-When we install a dependency from binaries, it brings all its own
-dependencies along with it. But when we build it from source, we need to
-manually install these indirect dependencies through `packages.apt`. In
-the example above, this means appending `ign-rendering`'s dependencies like
-`libogre-2.1-dev` to the other dependencies already in `ign-gui`'s
-`packages.apt`.
+In this example, `gz-rendering`'s dependencies will be installed from its own
+`packages.apt` files.
 
 ### Codecov
 
@@ -95,6 +91,7 @@ token and add it through the `codecov-token-private-repos` input. For example:
 You can add optional scripts to be run at specific times of the build. They can
 be either in `.github/ci` or `/github/ci-<system version>` as needed.
 
+* `before_dep_compilation.sh`: Runs before dependencies are compiled from source
 * `before_cmake.sh`: Runs before the `cmake` call
 * `between_cmake_make.sh`: Runs after the `cmake` and before `make`
 * `after_make.sh`: Runs after `make` and before `make test`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,8 @@ SYSTEM_VERSION=`lsb_release -cs`
 
 SOURCE_DEPENDENCIES="`pwd`/.github/ci/dependencies.yaml"
 SOURCE_DEPENDENCIES_VERSIONED="`pwd`/.github/ci-$SYSTEM_VERSION/dependencies.yaml"
+SCRIPT_BEFORE_DEP_COMPILATION="`pwd`/.github/ci/before_dep_compilation.sh"
+SCRIPT_BEFORE_DEP_COMPILATION_VERSIONED="`pwd`/.github/ci-$SYSTEM_VERSION/before_dep_compilation.sh"
 SCRIPT_BEFORE_CMAKE="`pwd`/.github/ci/before_cmake.sh"
 SCRIPT_BEFORE_CMAKE_VERSIONED="`pwd`/.github/ci-$SYSTEM_VERSION/before_cmake.sh"
 SCRIPT_BETWEEN_CMAKE_MAKE="`pwd`/.github/ci/between_cmake_make.sh"
@@ -94,6 +96,17 @@ apt -y install \
   $OLD_APT_DEPENDENCIES \
   $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
 echo ::endgroup::
+
+if [ -f "$SCRIPT_BEFORE_DEP_COMPILATION" ] || [ -f "$SCRIPT_BEFORE_DEP_COMPILATION_VERSIONED" ] ; then
+  echo ::group::Script before dependencies compilation from source
+  if [ -f "$SCRIPT_BEFORE_DEP_COMPILATION" ] ; then
+    . $SCRIPT_BEFORE_DEP_COMPILATION
+  fi
+  if [ -f "$SCRIPT_BEFORE_DEP_COMPILATION_VERSIONED" ] ; then
+    . $SCRIPT_BEFORE_DEP_COMPILATION_VERSIONED
+  fi
+  echo ::endgroup::
+fi
 
 if [ -f "$SOURCE_DEPENDENCIES" ] || [ -f "$SOURCE_DEPENDENCIES_VERSIONED" ] ; then
   echo ::group::Compile dependencies from source


### PR DESCRIPTION
I tested in this PR: https://github.com/gazebosim/gz-garden/pull/10

I added a script to uninstall some apt packages and it ran correctly:

```
2022-05-09T19:53:55.7364123Z + '[' -f /github/workspace/.github/ci/before_dep_compilation.sh ']'
2022-05-09T19:53:55.7370038Z + echo ::group::Script before dependencies compilation from source
2022-05-09T19:53:55.7370732Z ##[group]Script before dependencies compilation from source
2022-05-09T19:53:55.7373820Z + '[' -f /github/workspace/.github/ci/before_dep_compilation.sh ']'
2022-05-09T19:53:55.7376174Z + . /github/workspace/.github/ci/before_dep_compilation.sh
2022-05-09T19:53:55.7377042Z ++ apt-get purge -y '.*ignition.*' '.*sdformat.*'
```