### PR TITLE
Allow pip to install on the system on Noble

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,10 @@ apt -y install \
   python3-pip \
   wget
 
+# Allowing pip to install packages in the system
+mkdir -p "${HOME}/.config/pip"
+echo -e '[global]\nbreak-system-packages = true' > "${HOME}/.config/pip/pip.conf"
+
 if [ -n "$DOXYGEN_ENABLED" ] && ${DOXYGEN_ENABLED} ; then
   apt -y install doxygen
 fi


### PR DESCRIPTION
Keep the system pip installations working on Noble by explicitly set the "break-system-packages" option after changes from https://peps.python.org/pep-0668/