### PR TITLE
Add Action for validating package.xml files

### DIFF
--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -11,7 +11,10 @@ runs:
       run: |
         echo "Install ament-xmllint"
         sudo apt-get update
-        sudo apt-get install -y python3-ament-xmllint
+        sudo apt-get install -y python3-venv
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install ament-xmllint
         ament_xmllint package.xml 2>&1 | tee $GITHUB_STEP_SUMMARY
 
     - name: package.xml and CMake versions match

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -11,7 +11,7 @@ runs:
       run: |
         echo "Install ament-xmllint"
         sudo apt-get update
-        sudo apt-get install -y python3-venv
+        sudo apt-get install -y python3-venv xmllint
         python3 -m venv .venv
         source .venv/bin/activate
         pip install ament-xmllint

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -6,6 +6,13 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: package.xml syntax validation
+      shell: bash
+      run: |
+        echo "Install ament-xmllint"
+        apt install python3-ament-xmllint
+        ament_xmllint package.xml | tee $GITHUB_STEP_SUMMARY
+
     - name: package.xml and CMake versions match
       shell: bash
       run: |

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -10,8 +10,9 @@ runs:
       shell: bash
       run: |
         echo "Extract version numbers and compare"
+        echo '## CMake and Package.xml Versions' >> $GITHUB_STEP_SUMMARY
         package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
-        echo "Version in package.xml: ${package_xml_version}"
+        echo "Version in package.xml: ${package_xml_version}" | tee -a $GITHUB_STEP_SUMMARY
         cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
-        echo "Version in CMake: ${cmake_version}"
+        echo "Version in CMake: ${cmake_version}" | tee -a $GITHUB_STEP_SUMMARY
         [ $package_xml_version = $cmake_version ]

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -6,15 +6,17 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: package.xml syntax validation
-      shell: bash
-      run: |
-        echo "Install ament-xmllint"
-        sudo apt-get install -y python3-venv libxml2-utils
-        python3 -m venv .venv
-        source .venv/bin/activate
-        pip install ament-xmllint
-        ament_xmllint package.xml 2>&1 | tee $GITHUB_STEP_SUMMARY
+    # TODO(azeey) Uncomment once https://github.com/ros-infrastructure/rep/pull/400
+    # is merged and the .xsd changes have propagated to ament_xmllint.
+    # - name: package.xml syntax validation
+    #   shell: bash
+    #   run: |
+    #     echo "Install ament-xmllint"
+    #     sudo apt-get install -y python3-venv libxml2-utils
+    #     python3 -m venv .venv
+    #     source .venv/bin/activate
+    #     pip install ament-xmllint
+    #     ament_xmllint package.xml 2>&1 | tee $GITHUB_STEP_SUMMARY
 
     - name: package.xml and CMake versions match
       shell: bash

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -10,7 +10,7 @@ runs:
       shell: bash
       run: |
         echo "Install ament-xmllint"
-        apt install python3-ament-xmllint
+        sudo apt-get install -y python3-ament-xmllint
         ament_xmllint package.xml | tee $GITHUB_STEP_SUMMARY
 
     - name: package.xml and CMake versions match

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -1,0 +1,17 @@
+name: 'Validate package.xml'
+description: 'Validate package.xml file'
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: package.xml and CMake versions match
+      shell: bash
+      run: |
+        echo "Extract version numbers and compare"
+        package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
+        echo "Version in package.xml: ${package_xml_version}"
+        cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
+        echo "Version in CMake: ${cmake_version}"
+        [ $package_xml_version = $cmake_version ]

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -10,8 +10,7 @@ runs:
       shell: bash
       run: |
         echo "Install ament-xmllint"
-        sudo apt-get update
-        sudo apt-get install -y python3-venv xmllint
+        sudo apt-get install -y python3-venv libxml2-utils
         python3 -m venv .venv
         source .venv/bin/activate
         pip install ament-xmllint

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -10,8 +10,9 @@ runs:
       shell: bash
       run: |
         echo "Install ament-xmllint"
+        sudo apt-get update
         sudo apt-get install -y python3-ament-xmllint
-        ament_xmllint package.xml | tee $GITHUB_STEP_SUMMARY
+        ament_xmllint package.xml 2>&1 | tee $GITHUB_STEP_SUMMARY
 
     - name: package.xml and CMake versions match
       shell: bash


### PR DESCRIPTION
Per the conversation in https://github.com/gazebosim/gz-cmake/pull/413#discussion_r1525525965, this adds an Action that can be used in all of our Harmonic packages to check that the versions in CMake and package.xml are consistent.

See usage in https://github.com/gazebosim/gz-cmake/pull/413

I'm adding this to the `jammy` branch, but I'm open to using a different branch. I think we can actually consolidate the `focal`, `jammy`, and now `noble` branches into one branch with different directories for each version. We might even be able to consolidate the actions so we don't need three different versions. But for now, I thought the easiest thing was to add it to the branch we mostly use in Harmonic branches.