### PR TITLE
Add simple test results summary

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -200,6 +200,7 @@ if [ -n "$TESTS_ENABLED" ] && ${TESTS_ENABLED} ; then
   export CTEST_OUTPUT_ON_FAILURE=1
   cd "$GITHUB_WORKSPACE"/build
   make test
+  python3 /junit_to_md.py test_results/*.xml >> $GITHUB_STEP_SUMMARY
   echo ::endgroup::
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -200,7 +200,7 @@ if [ -n "$TESTS_ENABLED" ] && ${TESTS_ENABLED} ; then
   export CTEST_OUTPUT_ON_FAILURE=1
   cd "$GITHUB_WORKSPACE"/build
   make test
-  python3 /junit_to_md.py test_results/*.xml >> $GITHUB_STEP_SUMMARY
+  python3 /junit_to_md.py test_results/*.xml >> $GITHUB_STEP_SUMMARY || true
   echo ::endgroup::
 fi
 

--- a/junit_to_md.py
+++ b/junit_to_md.py
@@ -20,7 +20,7 @@ print()
 
 for doc in docs:
     for testsuite in doc.findall('testsuite'):
-        print(f'<details><summary><h4>{testsuite.attrib["name"]}</h4></summary>\n')
+        print(f'<details><summary>\n\n#### {testsuite.attrib["name"]}\n</summary>\n')
         print('| Status | Name | Time |')
         print('| ------ | ---- | ---- |')
         for testcase in doc.findall('testsuite/testcase'):

--- a/junit_to_md.py
+++ b/junit_to_md.py
@@ -20,7 +20,7 @@ print()
 
 for doc in docs:
     for testsuite in doc.findall('testsuite'):
-        print(f'<details><summary>{testsuite.attrib["name"]}</summary>\n')
+        print(f'<details><summary><h4>{testsuite.attrib["name"]}</h4></summary>\n')
         print('| Status | Name | Time |')
         print('| ------ | ---- | ---- |')
         for testcase in doc.findall('testsuite/testcase'):

--- a/junit_to_md.py
+++ b/junit_to_md.py
@@ -12,15 +12,14 @@ for file in sys.argv[1:]:
             status = "Failed ❌"
         else:
             status = "Passed ✅"
-        slug = testsuite.attrib['name'].lower()
-        print('| {status} | [{name}](#{slug}) | {tests} | {failures} | {disabled} | {skipped} | {errors} | {time} |'.format(status=status, **testsuite.attrib, slug=slug))
+        print('| {status} | {name} | {tests} | {failures} | {disabled} | {skipped} | {errors} | {time} |'.format(status=status, **testsuite.attrib))
 
 
 print()
 
 for doc in docs:
     for testsuite in doc.findall('testsuite'):
-        print(f'<details><summary>\n\n#### {testsuite.attrib["name"]}\n</summary>\n')
+        print(f'<details><summary>{testsuite.attrib["name"]}</summary>\n')
         print('| Status | Name | Time |')
         print('| ------ | ---- | ---- |')
         for testcase in doc.findall('testsuite/testcase'):

--- a/junit_to_md.py
+++ b/junit_to_md.py
@@ -1,0 +1,46 @@
+import sys
+from xml.etree import ElementTree as ET
+
+print('| Status | Name | Tests | Failures | Disabled | Skipped | Errors | Time |')
+print('| ------ | ---- | ----- | -------- | -------- | ------- | ------ | ---- |')
+docs = []
+for file in sys.argv[1:]:
+    doc = ET.parse(file)
+    docs.append(doc)
+    for testsuite in doc.findall('testsuite'):
+        if int(testsuite.attrib['failures']) > 0:
+            status = "Failed ❌"
+        else:
+            status = "Passed ✅"
+        slug = testsuite.attrib['name'].lower()
+        print('| {status} | [{name}](#{slug}) | {tests} | {failures} | {disabled} | {skipped} | {errors} | {time} |'.format(status=status, **testsuite.attrib, slug=slug))
+
+
+print()
+
+for doc in docs:
+    for testsuite in doc.findall('testsuite'):
+        print(f'<details><summary>{testsuite.attrib["name"]}</summary>\n')
+        print('| Status | Name | Time |')
+        print('| ------ | ---- | ---- |')
+        for testcase in doc.findall('testsuite/testcase'):
+            failures = testcase.findall('failure')
+            failed = len(failures) > 0
+            if failed:
+                status = "Failed ❌"
+            else:
+                status = "Passed ✅"
+            print("| {fail_status} |{classname}.{name} | {time} |".format(**testcase.attrib, fail_status=status))
+
+        print()
+        for testcase in doc.findall('testsuite/testcase'):
+            failures = testcase.findall('failure')
+            if len(failures) > 0:
+                print('<details><summary>Failure messages for {classname}.{name}</summary>'.format(**testcase.attrib))
+                print('\n```sh')
+                for failure in failures:
+                    print(failure.attrib['message'])
+                print('```\n')
+                print('</details>')
+        print('</details>\n')
+


### PR DESCRIPTION
Adds a table of the test results in the Summary of a Github workflow

Example: https://github.com/azeey/gz-utils/actions/runs/8605911917/attempts/6