### PR TITLE
Summarize tests even on test failure

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -199,8 +199,13 @@ if [ -n "$TESTS_ENABLED" ] && ${TESTS_ENABLED} ; then
   echo ::group::make test
   export CTEST_OUTPUT_ON_FAILURE=1
   cd "$GITHUB_WORKSPACE"/build
-  make test
+  # Capture exit code to avoid exiting early
+  make test || test_exit_code=$?
+  echo "Summarize test results"
   python3 /junit_to_md.py test_results/*.xml >> $GITHUB_STEP_SUMMARY || true
+  if [ $test_exit_code -ne 0 ]; then 
+    exit $test_exit_code ;
+  fi
   echo ::endgroup::
 fi
 


### PR DESCRIPTION
#71 doesn't work if there are test failures because the bash script exits immediately when it encounters an error code (due to `set -e`). This patch captures the error code, generates the summary and exits if there is an error code.

Example: https://github.com/azeey/gz-utils/actions/runs/8619758687/attempts/1#summary-23625135687