### PR TITLE
Fix exit code check to be more robust

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -203,7 +203,7 @@ if [ -n "$TESTS_ENABLED" ] && ${TESTS_ENABLED} ; then
   make test || test_exit_code=$?
   echo "Summarize test results"
   python3 /junit_to_md.py test_results/*.xml >> $GITHUB_STEP_SUMMARY || true
-  if [ $test_exit_code -ne 0 ]; then 
+  if [[ $test_exit_code -ne 0 ]]; then
     exit $test_exit_code ;
   fi
   echo ::endgroup::


### PR DESCRIPTION
When the test runs without any failures and exits with code 0, `test_exit_code` is not set. The single bracket if condition did not handle this properly. See https://github.com/gazebosim/gz-launch/actions/runs/9291421518/job/25569868453?pr=265