### PR TITLE
Install colcon and vcs from packages

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,10 @@ apt -y install \
   python3-pip \
   wget
 
+# Allowing pip to install packages in the system
+mkdir -p "${HOME}/.config/pip"
+echo -e '[global]\nbreak-system-packages = true' > "${HOME}/.config/pip/pip.conf"
+
 if [ -n "$DOXYGEN_ENABLED" ] && ${DOXYGEN_ENABLED} ; then
   apt -y install doxygen
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,13 +86,6 @@ pip3 install -r /tmp/gzdev/requirements.txt --break-system-packages
 apt-get update 2>&1
 echo ::endgroup::
 
-echo ::group::Install tools: source
-git clone https://github.com/linux-test-project/lcov.git -b v1.14 2>&1
-cd lcov
-make install
-cd ..
-echo ::endgroup::
-
 if [ -f "$SOURCE_DEPENDENCIES" ] || [ -f "$SOURCE_DEPENDENCIES_VERSIONED" ] ; then
   echo ::group::Fetch source dependencies
   mkdir -p deps/src

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,11 +35,6 @@ apt -y install \
   python3-vcstool \
   wget
 
-# Add colcon repository
-mkdir -p /etc/apt/keyrings/
-curl -fsSL https://packagecloud.io/dirk-thomas/colcon/gpgkey | gpg --dearmor > /etc/apt/keyrings/colcon-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=signed-by=/etc/apt/keyrings/colcon-archive-keyring.gpg https://packagecloud.io/dirk-thomas/colcon/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/colcon.list > /dev/null
-
 if [ -n "$DOXYGEN_ENABLED" ] && ${DOXYGEN_ENABLED} ; then
   apt -y install doxygen
 fi
@@ -87,6 +82,15 @@ apt-get update 2>&1
 echo ::endgroup::
 
 if [ -f "$SOURCE_DEPENDENCIES" ] || [ -f "$SOURCE_DEPENDENCIES_VERSIONED" ] ; then
+  echo ::group::Prepare colcon and vcs for source dependencies
+  # Add colcon repository
+  mkdir -p /etc/apt/keyrings/
+  curl -fsSL https://packagecloud.io/dirk-thomas/colcon/gpgkey | gpg --dearmor > /etc/apt/keyrings/colcon-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=signed-by=/etc/apt/keyrings/colcon-archive-keyring.gpg https://packagecloud.io/dirk-thomas/colcon/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/colcon.list > /dev/null
+  apt update 2>&1
+  apt -y install python3-vcstool \
+                 python3-colcon-common-extensions
+  echo ::endgroup::
   echo ::group::Fetch source dependencies
   mkdir -p deps/src
   if [ -f "$SOURCE_DEPENDENCIES" ] ; then
@@ -100,7 +104,6 @@ fi
 
 echo ::group::Install dependencies from binaries
 apt -y install \
-  python3-colcon-common-extensions
   $OLD_APT_DEPENDENCIES \
   $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
 echo ::endgroup::

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,8 +84,10 @@ if [ -f "$SOURCE_DEPENDENCIES" ] || [ -f "$SOURCE_DEPENDENCIES_VERSIONED" ] ; th
   echo ::group::Prepare colcon and vcs for source dependencies
   # Add colcon repository
   mkdir -p /etc/apt/keyrings/
-  curl -fsSL https://packagecloud.io/dirk-thomas/colcon/gpgkey | gpg --dearmor > /etc/apt/keyrings/colcon-archive-keyring.gpg
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=signed-by=/etc/apt/keyrings/colcon-archive-keyring.gpg https://packagecloud.io/dirk-thomas/colcon/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/colcon.list > /dev/null
+  for tool in colcon vcstool; do
+    curl -fsSL "https://packagecloud.io/dirk-thomas/${tool}/gpgkey" | gpg --dearmor > "/etc/apt/keyrings/${tool}-archive-keyring.gpg"
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/${tool}-archive-keyring.gpg] https://packagecloud.io/dirk-thomas/${tool}/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/${tool}.list > /dev/null
+  done
   apt update 2>&1
   apt -y install python3-vcstool \
                  python3-colcon-common-extensions

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,6 @@ apt -y install \
   lcov \
   lsb-release \
   python3-pip \
-  python3-vcstool \
   wget
 
 if [ -n "$DOXYGEN_ENABLED" ] && ${DOXYGEN_ENABLED} ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,11 +32,13 @@ apt -y install \
   lcov \
   lsb-release \
   python3-pip \
+  python3-vcstool \
   wget
 
-# Allowing pip to install packages in the system
-mkdir -p "${HOME}/.config/pip"
-echo -e '[global]\nbreak-system-packages = true' > "${HOME}/.config/pip/pip.conf"
+# Add colcon repository
+mkdir -p /etc/apt/keyrings/
+curl -fsSL https://packagecloud.io/dirk-thomas/colcon/gpgkey | gpg --dearmor > /etc/apt/keyrings/colcon-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=signed-by=/etc/apt/keyrings/colcon-archive-keyring.gpg https://packagecloud.io/dirk-thomas/colcon/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/colcon.list > /dev/null
 
 if [ -n "$DOXYGEN_ENABLED" ] && ${DOXYGEN_ENABLED} ; then
   apt -y install doxygen
@@ -84,8 +86,11 @@ pip3 install -r /tmp/gzdev/requirements.txt --break-system-packages
 apt-get update 2>&1
 echo ::endgroup::
 
-echo ::group::Install tools: pip
-pip3 install -U pip vcstool colcon-common-extensions --break-system-packages
+echo ::group::Install tools: source
+git clone https://github.com/linux-test-project/lcov.git -b v1.14 2>&1
+cd lcov
+make install
+cd ..
 echo ::endgroup::
 
 if [ -f "$SOURCE_DEPENDENCIES" ] || [ -f "$SOURCE_DEPENDENCIES_VERSIONED" ] ; then
@@ -102,6 +107,7 @@ fi
 
 echo ::group::Install dependencies from binaries
 apt -y install \
+  python3-colcon-common-extensions
   $OLD_APT_DEPENDENCIES \
   $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
 echo ::endgroup::


### PR DESCRIPTION
This is a sidecar of #78 . Now that the use of pip for system-wide packages is restricted and dangerous, we probably want to stop using it as a package manager for our system installations.

vcs is not that critical but for colcon the use of it from a virtualenv is affecting the platform for getting system dependencies at build time, something that is more a side effect and not desired action. See the use of of colcon with system-dependencies for gz in #78.

In this PR I'm mainly getting:
  * ~python3-vcstool from Ubuntu~ vcstool from its packagecloud repository
  * colcon from its packagecloud repository
  