### PR TITLE
validate_package_xml: check with xmllint

### DIFF
--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -6,13 +6,16 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: package.xml syntax validation
+      shell: bash
+      run: |
+        echo "Install xmllint"
+        sudo apt-get install -y libxml2-utils
+        xmllint --noout package.xml
     # TODO(azeey) Uncomment once https://github.com/ros-infrastructure/rep/pull/400
     # is merged and the .xsd changes have propagated to ament_xmllint.
-    # - name: package.xml syntax validation
-    #   shell: bash
-    #   run: |
     #     echo "Install ament-xmllint"
-    #     sudo apt-get install -y python3-venv libxml2-utils
+    #     sudo apt-get install -y python3-venv
     #     python3 -m venv .venv
     #     source .venv/bin/activate
     #     pip install ament-xmllint

--- a/validate_package_xml/action.yml
+++ b/validate_package_xml/action.yml
@@ -6,6 +6,17 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: package.xml and CMake versions match
+      shell: bash
+      run: |
+        echo "Extract version numbers and compare"
+        echo '## CMake and Package.xml Versions' >> $GITHUB_STEP_SUMMARY
+        package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
+        echo "Version in package.xml: ${package_xml_version}" | tee -a $GITHUB_STEP_SUMMARY
+        cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
+        echo "Version in CMake: ${cmake_version}" | tee -a $GITHUB_STEP_SUMMARY
+        [ $package_xml_version = $cmake_version ]
+
     - name: package.xml syntax validation
       shell: bash
       run: |
@@ -20,14 +31,3 @@ runs:
     #     source .venv/bin/activate
     #     pip install ament-xmllint
     #     ament_xmllint package.xml 2>&1 | tee $GITHUB_STEP_SUMMARY
-
-    - name: package.xml and CMake versions match
-      shell: bash
-      run: |
-        echo "Extract version numbers and compare"
-        echo '## CMake and Package.xml Versions' >> $GITHUB_STEP_SUMMARY
-        package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
-        echo "Version in package.xml: ${package_xml_version}" | tee -a $GITHUB_STEP_SUMMARY
-        cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
-        echo "Version in CMake: ${cmake_version}" | tee -a $GITHUB_STEP_SUMMARY
-        [ $package_xml_version = $cmake_version ]


### PR DESCRIPTION
Fixes https://github.com/gazebo-tooling/action-gz-ci/issues/84.

## Summary

There is a commented bit of code to use `ament_xmllint` that is waiting on https://github.com/ros-infrastructure/rep/pull/400 to be merged. In the meantime, just use `xmllint --noout` to check for XML syntax errors (see https://github.com/gazebo-tooling/action-gz-ci/pull/85/commits/ca4011a2ac3ec8fced8989ed2fda5ee2fc42710f).

Since installing `libxml2-utils` can be slow, move the XML syntax after the version check (see https://github.com/gazebo-tooling/action-gz-ci/pull/85/commits/41a3184e6bf7ffc4d069beb4b3e8a4fd1647e800).



## Testing

Tested in https://github.com/gazebosim/gz-jetty/pull/118:

* https://github.com/gazebosim/gz-jetty/pull/118/commits/eff53485dd349ad4d120a532e8790b7119ffc158: passes with this branch
* https://github.com/gazebosim/gz-jetty/pull/118/commits/57f34e7584db4471ae666a3874991c0dc60380ea: fails after adding a syntax error