### PR TITLE
Add gzdev-project-name input to override auto-derived project name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: 'Run cppcheck'
     required: false
     default: 'false'
+  gzdev-project-name:
+    description: 'Override the gzdev project name (default: auto-derived from repo name + CMake major version)'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -55,3 +59,4 @@ runs:
     - ${{ inputs.tests-enabled }}
     - ${{ inputs.cpplint-enabled }}
     - ${{ inputs.cppcheck-enabled }}
+    - ${{ inputs.gzdev-project-name }}

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     required: false
     default: 'false'
   gzdev-project-name:
-    description: 'Override the gzdev project name (default: auto-derived from repo name + CMake major version)'
+    description: 'Override the gzdev project name (default: auto-derived from repo name + CMake major version). e.g., This can be set to "rotary" to enable the use the nightlies apt repo.'
     required: false
     default: ''
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ DOXYGEN_ENABLED=$6
 TESTS_ENABLED=$7
 CPPLINT_ENABLED=$8
 CPPCHECK_ENABLED=$9
+GZDEV_PROJECT_NAME=${10}
 
 # keep the previous behaviour of running codecov if old token is set
 [ -n "${DEPRECATED_CODECOV_TOKEN}" ] && CODECOV_ENABLED=1
@@ -74,8 +75,13 @@ if [ -n "${GZDEV_TRY_BRANCH}" ]; then
   git -C /tmp/gzdev checkout ${GZDEV_TRY_BRANCH} || true
 fi
 pip3 install -r /tmp/gzdev/requirements.txt --break-system-packages
+if [ -n "${GZDEV_PROJECT_NAME}" ]; then
+  GZDEV_PROJECT="${GZDEV_PROJECT_NAME}"
+else
+  GZDEV_PROJECT="${PACKAGE}${PACKAGE_MAJOR_VERSION}"
+fi
 /tmp/gzdev/gzdev.py \
-  repository enable --project="${PACKAGE}${PACKAGE_MAJOR_VERSION}"
+  repository enable --project="${GZDEV_PROJECT}"
 
 apt-get update 2>&1
 echo ::endgroup::


### PR DESCRIPTION
Appear https://github.com/gazebosim/gz-utils/pull/206. Related to https://github.com/gazebo-tooling/release-tools/issues/1446

Allow callers to specify a custom gzdev project name instead of the default ${PACKAGE}${PACKAGE_MAJOR_VERSION}. This is needed for branches targeting unreleased collections where the auto-derived project may not exist yet (e.g., use "nightly" instead).

